### PR TITLE
renaming must also be done for "allDevices"

### DIFF
--- a/_all_CustomDevices/MFCustomDevice.cpp
+++ b/_all_CustomDevices/MFCustomDevice.cpp
@@ -68,10 +68,10 @@ MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrCo
         is used to store the type
     ********************************************************************************** */
     getStringFromEEPROM(adrType, parameter);
-    if (strcmp(parameter, "KAV_LCD_FCU") == 0)
-        _customType = KAV_LCD_FCU;
-    else if (strcmp(parameter, "KAV_LCD_EFIS") == 0)
-        _customType = KAV_LCD_EFIS;
+    if (strcmp(parameter, "KAV_FCU") == 0)
+        _customType = KAV_FCU;
+    else if (strcmp(parameter, "KAV_EFIS") == 0)
+        _customType = KAV_EFIS;
     else if (strcmp(parameter, "MOBIFLIGHT_GNC255") == 0)
         _customType = MOBIFLIGHT_GNC255;
     else if (strcmp(parameter, "MOBIFLIGHT_GENERICI2C") == 0)

--- a/_all_CustomDevices/MFCustomDevice.h
+++ b/_all_CustomDevices/MFCustomDevice.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <Arduino.h>
-#include "../KAV_Simulation/EFIS_FCU/KAV_A3XX_FCU_LCD.h"
-#include "../KAV_Simulation/EFIS_FCU/KAV_A3XX_EFIS_LCD.h"
+#include "../KAV_Simulation/KAV_A3XX_FCU_LCD.h"
+#include "../KAV_Simulation/KAV_A3XX_EFIS_LCD.h"
 #include "../Mobiflight/GNC255/GNC255.h"
 #include "../Mobiflight/GenericI2C/GenericI2C.h"
 
 enum {
-    KAV_LCD_FCU,
-    KAV_LCD_EFIS,
+    KAV_FCU,
+    KAV_EFIS,
     MOBIFLIGHT_GNC255,
     MOBIFLIGHT_GENERICI2C
 };


### PR DESCRIPTION
For build of all custom devices in one FW version renaming for KAV displays was missing,