### PR TITLE
Add custom name to .ini file

### DIFF
--- a/KAV_Simulation/displays_platformio.ini
+++ b/KAV_Simulation/displays_platformio.ini
@@ -13,6 +13,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 			 			; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"			 			; TBD!! how to handle FW versions for custom devices
 	'-DMOBIFLIGHT_TYPE="Kav Mega"' 						; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Kav Mega"' 						; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/Atmel/Board_Mega						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/KAV_Simulation					; Include files for your custom device, replace "_template" by your folder name
@@ -44,6 +45,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 			 			; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"			 			; TBD!! how to handle FW versions for custom devices
 	'-DMOBIFLIGHT_TYPE="Kav RaspiPico"'					; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Kav RaspiPico"' 				; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/RaspberryPi/Pico						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/KAV_Simulation					; Include files for your custom device, replace "_template" by your folder name

--- a/Mobiflight/GNC255/GNC255_platformio.ini
+++ b/Mobiflight/GNC255/GNC255_platformio.ini
@@ -11,6 +11,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 			 			; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"			 			; TBD!! how to handle FW versions for custom devices
 	'-DMOBIFLIGHT_TYPE="MobiFlight GNC255 Mega"' 		; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="MobiFlight GNC255 Mega"' 		; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/Atmel/Board_Mega						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/Mobiflight/GNC255					; Include files for your custom device, replace "_template" by your folder name
@@ -44,6 +45,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 			 			; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"			 			; TBD!! how to handle FW versions for custom devices
 	'-DMOBIFLIGHT_TYPE="MobiFlight GNC255 Pico"' 		; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="MobiFlight GNC255 Pico"' 		; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/RaspberryPi/Pico						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/Mobiflight/GNC255					; Include files for your custom device, replace "_template" by your folder name

--- a/Mobiflight/GenericI2C/GenericI2C_platformio.ini
+++ b/Mobiflight/GenericI2C/GenericI2C_platformio.ini
@@ -13,7 +13,8 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_HAS_UPDATE						; if the custom device needs to be updated, uncomment this. W/o the following define it will be done each loop()
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 						; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"						; TBD!! how to handle custom firmware versions!!
-	'-DMOBIFLIGHT_TYPE="MobiFlight GenericI2C Mega"'		; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_TYPE="MobiFlight GenericI2C Mega"'	; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="MobiFlight GenericI2C Mega"' 	; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/Atmel/Board_Mega						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/Mobiflight/GenericI2C				; Include files for your custom device, replace "_template" by your folder name
@@ -45,6 +46,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 						; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"						; TBD!! how to handle custom firmware versions!!
 	'-DMOBIFLIGHT_TYPE="MobiFlight GenericI2C RaspiPico"'	; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="MobiFlight GenericI2C RaspiPico"' 	; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/RaspberryPi/Pico						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/Mobiflight/GenericI2C				; Include files for your custom device, replace "_template" by your folder name

--- a/_all_CustomDevices/all_devices_platformio.ini
+++ b/_all_CustomDevices/all_devices_platformio.ini
@@ -13,6 +13,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 			 			; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"			 			; TBD!! how to handle FW versions for custom devices
 	'-DMOBIFLIGHT_TYPE="All devices Mega"' 				; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="All devices Mega"' 				; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/Atmel/Board_Mega
 	-I./src/MF_CustomDevice
 	-I./CustomDevices/_all_CustomDevices				; add include path for all custom devices
@@ -51,6 +52,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 			 			; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"			 			; TBD!! how to handle FW versions for custom devices
 	'-DMOBIFLIGHT_TYPE="All devices RaspiPico"'			; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="All devices RaspiPico"' 		; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/RaspberryPi/Pico
 	-I./src/MF_CustomDevice
 	-I./CustomDevices/_all_CustomDevices				; add include path for all custom devices

--- a/_template/MyCustomDevice_platformio.ini
+++ b/_template/MyCustomDevice_platformio.ini
@@ -14,6 +14,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 						; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"						; TBD!! how to handle custom firmware versions!!
 	'-DMOBIFLIGHT_TYPE="Mobiflight Template Mega"'		; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Mobiflight Template Mega"' 		; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/Atmel/Board_Mega						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/_template							; Include files for your custom device, replace "_template" by your folder name
@@ -45,6 +46,7 @@ build_flags =
 	;-DMF_CUSTOMDEVICE_POLL_MS=10 						; time in ms between updating custom device, uncomment this if custom device needs to be updated regulary
 	;-DCUSTOM_FIRMWARE_VERSION="1"						; TBD!! how to handle custom firmware versions!!
 	'-DMOBIFLIGHT_TYPE="Mobiflight Template RaspiPico"'	; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Mobiflight Template RaspiPico"'	; this will show up as Name in the settings dialog unless it gets change from there
 	-I./_Boards/RaspberryPi/Pico						; Include the required board definition. If you need your own definition, adapt this to your path (e.g. -I./CustomDevices/_template/_Boards)
 	-I./src/MF_CustomDevice								; don't change this one!
 	-I./CustomDevices/_template							; Include files for your custom device, replace "_template" by your folder name


### PR DESCRIPTION
For now the name from the custom board is the standard name defined in `MFBoards.h`.

With this change the custom board gets also a custom name which shows up in the settings dialog from the connector.