### PR TITLE
send long messages also for AVR's

### DIFF
--- a/Mobiflight/GenericI2C/GenericI2C.cpp
+++ b/Mobiflight/GenericI2C/GenericI2C.cpp
@@ -1,12 +1,12 @@
 #include "GenericI2C.h"
-#include "allocateMem.h"
-#include "commandmessenger.h"
 #include <Wire.h>
 
-/* **********************************************************************************
-    This is just the basic code to set up your custom device.
-    Change/add your code as needed.
-********************************************************************************** */
+#define END_OF_I2C_MESSAGE              0x00
+#define END_OF_I2C_COMMAND              0x0D        // carriage return in ASCII
+#define END_OF_I2C_PARTIAL_MESSAGE      0x0A        // line feed in ASCII
+#if defined(ARDUINO_ARCH_RP2040)
+  #define BUFFER_LENGTH                 WIRE_BUFFER_SIZE
+#endif
 
 GenericI2C::GenericI2C(uint8_t addrI2C)
 {
@@ -31,21 +31,37 @@ void GenericI2C::detach()
     _initialised = false;
 }
 
+
 void GenericI2C::set(int16_t messageID, char *setPoint)
 {
     /* **********************************************************************************
         MessageID and setpoint will be send via I2C
+        For AVR's the I2C buffer is only 32 bytes, so message gets spilt up if exceeding
+        max. length of a message could be 96 bytes due to limitation from the CMDmessenger
         Important Remark!
         MessageID == -1 will be send from the connector when Mobiflight is closed
         MessageID == -2 will be send from the connector when PowerSavingMode is entered
     ********************************************************************************** */
     char buffer[7] = {0};
+    uint8_t countChar = 0;
+	uint8_t countI2C = 0;
+
     itoa(messageID, buffer, 10);
     Wire.beginTransmission(_addrI2C);
     Wire.print(buffer);
-    Wire.write(0x0D);   // send a CR to mark end of command
-    Wire.print(setPoint);
-    Wire.write(0x00);   // send a NULL to mark end of messageID
+    Wire.write(END_OF_I2C_COMMAND);                                     // send a CR to mark end of command
+    countI2C = strlen(buffer) + 1;                                      // count already transferred bytes incl. end of command marker
+    while (countChar < strlen(setPoint)) {
+        Wire.write(setPoint[countChar++]);
+        countI2C++;
+        if (countI2C >= (BUFFER_LENGTH - 1)) {							// if buffer will be exceeded on next characater, keep one byte for end of message marker
+            Wire.write(END_OF_I2C_PARTIAL_MESSAGE);                     // send a LF for next part of message
+			Wire.endTransmission();								        // write buffer to I2C display
+			Wire.beginTransmission(_addrI2C);							// and prepare a new transmission
+			countI2C = 0;												// start new Byte counting
+		}
+    }
+    Wire.write(END_OF_I2C_MESSAGE);                                     // send a NULL to mark end of messageID
     Wire.endTransmission();
 }
 


### PR DESCRIPTION
longer messages than ~30 bytes (depending on messageID size) will not be transfered via I2C from AVR's as the I2C buffer for AVR's is only 32 bytes.
If the message exceeds the buffer, the message will be split up and each package is send with a LF delimiter.