### PR TITLE
handle long messages in example

### DIFF
--- a/Mobiflight/GenericI2C/example/slave_I2C.ino
+++ b/Mobiflight/GenericI2C/example/slave_I2C.ino
@@ -1,9 +1,13 @@
 #include <Arduino.h>
 #include "Wire.h"
 
-#define I2C_MOBIFLIGHT_ADDR     0x27
-//#define BUFFER_LENGTH         I2C_BUFFER_LENGTH   // uncomment this for ESP32
-//#define BUFFER_LENGTH         WIRE_BUFFER_SIZE    // uncomment this for Raspberry Pico
+#define I2C_MOBIFLIGHT_ADDR             0x27
+
+#define END_OF_I2C_MESSAGE              0x00
+#define END_OF_I2C_COMMAND              0x0D      // carriage return in ASCII
+#define END_OF_I2C_PARTIAL_MESSAGE      0x0A      // line feed in ASCII
+#define MAX_LENGTH_MESSAGE              80        // max length of a message is 80 bytes due to limitations of the CMDmessenger
+
 
 enum {
     NOT_SYNCHRONIZED = 0,
@@ -14,7 +18,7 @@ enum {
 void onReceiveI2C(int len);
 
 int16_t messageID = 0;
-char message[BUFFER_LENGTH];
+char message[MAX_LENGTH_MESSAGE];
 bool message_received = false;
 
 
@@ -71,42 +75,52 @@ void loop() {
 
 
 // callback function for I2C receive
-void onReceiveI2C(int received_bytes) { 
+void onReceiveI2C(int received_bytes) {
 
-static uint8_t byte_counter = 0;
-static uint8_t state = RECEIVE_COMMAND;
-char buffer[7] = {0};                                 // range is -32768 ... 32767 -> max. 6 character plus terminating NULL
-
-  if (state == NOT_SYNCHRONIZED) {
-    for (uint8_t i = 0; i < received_bytes; i++) {
-      if (Wire.read() == 0) {                         // wait for 0x00 to get synchronized
-        state = RECEIVE_COMMAND;
-        break;
-      }
-      byte_counter++;
-    }
-    received_bytes -= byte_counter;
-    byte_counter = 0;
-  }
+  static uint8_t byte_counter = 0;
+  static uint8_t state = RECEIVE_COMMAND;
+  char buffer[7] = {0};                                    // range is -32768 ... 32767 -> max. 6 character plus terminating NULL
 
   for (uint8_t i = 0; i < received_bytes; i++) {
-    if (state == RECEIVE_COMMAND) {                    // first Bytes of message is the messageID
-        buffer[i] = Wire.read();
-      if (buffer[i] == 0x0D) {
-        buffer[i] = 0x00;
-        messageID = atoi(buffer);
-        state = RECEIVE_DATA;                         // next bytes are Data Bytes
-      }      
-    } else if(state == RECEIVE_DATA) {
-        message[byte_counter] = Wire.read();
-        if (message[byte_counter] == 0) {             // end of message detected, prepare for receiving next messageID
-          byte_counter = 0;
-          state = RECEIVE_COMMAND;
-          message_received = true;
-          return;
-        } else {
-          byte_counter++;
+    switch (state) {
+    case NOT_SYNCHRONIZED:
+      if (Wire.read() == END_OF_I2C_MESSAGE) {              // wait for end of message to get synchronized
+        state = RECEIVE_COMMAND;
+        byte_counter = 0;
       }
+      break;
+
+    case RECEIVE_COMMAND:
+      buffer[i] = Wire.read();
+      if (buffer[i] == END_OF_I2C_COMMAND) {
+        buffer[i] = 0x00;                                   // terminate string
+        messageID = atoi(buffer);
+        state = RECEIVE_DATA;                               // next bytes are Data Bytes
+      }
+      if (i >= 6) {                                         // buffer overflow for messageID
+        state == NOT_SYNCHRONIZED;                          // something went wrong, get a new synchronization
+        byte_counter = 0;
+        return;
+      }
+      break;
+
+    case RECEIVE_DATA:
+      message[byte_counter] = Wire.read();
+      if (message[byte_counter] == END_OF_I2C_MESSAGE) {    // end of message detected, prepare for receiving next messageID
+        byte_counter = 0;
+        state = RECEIVE_COMMAND;
+        message_received = true;
+        return;
+      } else if(message[byte_counter] == END_OF_I2C_PARTIAL_MESSAGE) {   // end of partial message detected, next transmission will be rest of message  
+        return;                                             // keep receiving data
+      } else {
+        byte_counter++;                                     // get the next byte
+      }
+      break;
+
+    default:
+      break;
     }
   }
+  state = NOT_SYNCHRONIZED;                                 // We shouldn't come here, something went wrong
 }


### PR DESCRIPTION
AVR's can only send max 32 bytes via I2C.
Example is extended to handle mutliple parts of a message as they are sent from the FW for longer messages.