### PR TITLE
Attach() function for initialization of devices

### DIFF
--- a/KAV_Simulation/MFCustomDevice.cpp
+++ b/KAV_Simulation/MFCustomDevice.cpp
@@ -43,6 +43,11 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     return true;
 }
 
+MFCustomDevice::MFCustomDevice()
+{
+    _initialized = false;
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.
@@ -52,7 +57,7 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     will be called
 ********************************************************************************** */
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+void MFCustomDevice::attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
 {
     if (adrPin == 0) return;
 

--- a/KAV_Simulation/MFCustomDevice.h
+++ b/KAV_Simulation/MFCustomDevice.h
@@ -11,7 +11,8 @@ enum {
 class MFCustomDevice
 {
 public:
-    MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
+    MFCustomDevice();
+    void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();
     void set(int16_t messageID, char *setPoint);

--- a/Mobiflight/GNC255/MFCustomDevice.cpp
+++ b/Mobiflight/GNC255/MFCustomDevice.cpp
@@ -38,6 +38,11 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     return true;
 }
 
+MFCustomDevice::MFCustomDevice()
+{
+    _initialized = false;
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.
@@ -47,7 +52,7 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     will be called
 ********************************************************************************** */
 
-MFCustomDevice::MFCustomDevice(int16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+void MFCustomDevice::attach(int16_t adrPin, uint16_t adrType, uint16_t adrConfig)
 {
     if (adrPin == 0) return;
 

--- a/Mobiflight/GNC255/MFCustomDevice.h
+++ b/Mobiflight/GNC255/MFCustomDevice.h
@@ -6,7 +6,8 @@
 class MFCustomDevice
 {
 public:
-    MFCustomDevice(int16_t adrPin, uint16_t adrType, uint16_t adrConfig);
+    MFCustomDevice();
+    void attach(int16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();
     void set(uint8_t messageID, char *setPoint);

--- a/Mobiflight/GenericI2C/GenericI2C.cpp
+++ b/Mobiflight/GenericI2C/GenericI2C.cpp
@@ -4,6 +4,8 @@
 #define END_OF_I2C_MESSAGE              0x00
 #define END_OF_I2C_COMMAND              0x0D        // carriage return in ASCII
 #define END_OF_I2C_PARTIAL_MESSAGE      0x0A        // line feed in ASCII
+#define SEND_MAX_I2C_BYTES              30          // mega has only 32 bytes buffer for receiving via I2C, keep one for additional message marker and one for stop message
+
 #if defined(ARDUINO_ARCH_RP2040)
   #define BUFFER_LENGTH                 WIRE_BUFFER_SIZE
 #endif
@@ -54,7 +56,7 @@ void GenericI2C::set(int16_t messageID, char *setPoint)
     while (countChar < strlen(setPoint)) {
         Wire.write(setPoint[countChar++]);
         countI2C++;
-        if (countI2C >= (BUFFER_LENGTH - 1)) {							// if buffer will be exceeded on next characater, keep one byte for end of message marker
+        if (countI2C >= SEND_MAX_I2C_BYTES) {							// if buffer will be exceeded on next characater, keep one byte for end of message marker
             Wire.write(END_OF_I2C_PARTIAL_MESSAGE);                     // send a LF for next part of message
 			Wire.endTransmission();								        // write buffer to I2C display
 			Wire.beginTransmission(_addrI2C);							// and prepare a new transmission

--- a/Mobiflight/GenericI2C/MFCustomDevice.cpp
+++ b/Mobiflight/GenericI2C/MFCustomDevice.cpp
@@ -38,6 +38,11 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     return true;
 }
 
+MFCustomDevice::MFCustomDevice()
+{
+    _initialized = false;
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.
@@ -47,7 +52,7 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     will be called
 ********************************************************************************** */
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+void MFCustomDevice::attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
 {
     if (adrPin == 0) return;
 

--- a/Mobiflight/GenericI2C/MFCustomDevice.h
+++ b/Mobiflight/GenericI2C/MFCustomDevice.h
@@ -10,7 +10,8 @@ enum {
 class MFCustomDevice
 {
 public:
-    MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
+    MFCustomDevice();
+    void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();
     void set(int16_t messageID, char *setPoint);

--- a/_all_CustomDevices/MFCustomDevice.cpp
+++ b/_all_CustomDevices/MFCustomDevice.cpp
@@ -43,6 +43,11 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     return true;
 }
 
+MFCustomDevice::MFCustomDevice()
+{
+    _initialized = false;
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.
@@ -52,7 +57,7 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     will be called
 ********************************************************************************** */
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+void MFCustomDevice::attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
 {
     if (adrPin == 0) return;
 

--- a/_all_CustomDevices/MFCustomDevice.h
+++ b/_all_CustomDevices/MFCustomDevice.h
@@ -16,7 +16,8 @@ enum {
 class MFCustomDevice
 {
 public:
-    MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
+    MFCustomDevice();
+    void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();
     void set(int16_t messageID, char *setPoint);

--- a/_template/MFCustomDevice.cpp
+++ b/_template/MFCustomDevice.cpp
@@ -38,6 +38,11 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     return true;
 }
 
+MFCustomDevice::MFCustomDevice()
+{
+    _initialized = false;
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.
@@ -47,7 +52,7 @@ bool MFCustomDevice::getStringFromEEPROM(uint16_t addreeprom, char *buffer)
     will be called
 ********************************************************************************** */
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+void MFCustomDevice::attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
 {
     if (adrPin == 0) return;
 

--- a/_template/MFCustomDevice.h
+++ b/_template/MFCustomDevice.h
@@ -11,7 +11,8 @@ enum {
 class MFCustomDevice
 {
 public:
-    MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
+    MFCustomDevice();
+    void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();
     void set(int16_t messageID, char *setPoint);


### PR DESCRIPTION
For the custom devices an attach() function ia added where all required init paramaters are transferred. These init parameters were part of the constructor.
Now calling the constructor will only set that the device is not initialized.

The calling of the constructor is since PR https://github.com/MobiFlight/MobiFlight-FirmwareSource/pull/253 also done to calculate the required memory for all devices of one type and to reserve it. As no init parameters are available at this point (0,0,0) were taken and in the constructor this was checked.

Now it is inline with all devices once PR https://github.com/MobiFlight/MobiFlight-FirmwareSource/pull/286 is merged.