### PR TITLE
add old constructor

### DIFF
--- a/KAV_Simulation/MFCustomDevice.cpp
+++ b/KAV_Simulation/MFCustomDevice.cpp
@@ -48,6 +48,11 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
+MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+{
+    attach(adrPin, adrType, adrConfig);
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/KAV_Simulation/MFCustomDevice.h
+++ b/KAV_Simulation/MFCustomDevice.h
@@ -12,6 +12,7 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
+    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/Mobiflight/GNC255/MFCustomDevice.cpp
+++ b/Mobiflight/GNC255/MFCustomDevice.cpp
@@ -43,6 +43,11 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
+MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+{
+    attach(adrPin, adrType, adrConfig);
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/Mobiflight/GNC255/MFCustomDevice.h
+++ b/Mobiflight/GNC255/MFCustomDevice.h
@@ -7,6 +7,7 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
+    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(int16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/Mobiflight/GenericI2C/MFCustomDevice.cpp
+++ b/Mobiflight/GenericI2C/MFCustomDevice.cpp
@@ -43,6 +43,11 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
+MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+{
+    attach(adrPin, adrType, adrConfig);
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/Mobiflight/GenericI2C/MFCustomDevice.h
+++ b/Mobiflight/GenericI2C/MFCustomDevice.h
@@ -11,6 +11,7 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
+    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/_all_CustomDevices/MFCustomDevice.cpp
+++ b/_all_CustomDevices/MFCustomDevice.cpp
@@ -48,6 +48,11 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
+MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+{
+    attach(adrPin, adrType, adrConfig);
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/_all_CustomDevices/MFCustomDevice.h
+++ b/_all_CustomDevices/MFCustomDevice.h
@@ -17,6 +17,7 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
+    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/_template/MFCustomDevice.cpp
+++ b/_template/MFCustomDevice.cpp
@@ -43,6 +43,11 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
+MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
+{
+    attach(adrPin, adrType, adrConfig);
+}
+
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/_template/MFCustomDevice.h
+++ b/_template/MFCustomDevice.h
@@ -12,6 +12,7 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
+    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();


### PR DESCRIPTION
As long as the [PR 286](https://github.com/MobiFlight/MobiFlight-FirmwareSource/pull/286) is not merged these changes are required to get the FW compiled.