### PR TITLE
constructor from class according mobiflight FW

### DIFF
--- a/KAV_Simulation/MFCustomDevice.cpp
+++ b/KAV_Simulation/MFCustomDevice.cpp
@@ -48,11 +48,6 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
-{
-    attach(adrPin, adrType, adrConfig);
-}
-
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/KAV_Simulation/MFCustomDevice.h
+++ b/KAV_Simulation/MFCustomDevice.h
@@ -12,7 +12,6 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
-    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/Mobiflight/GNC255/MFCustomDevice.cpp
+++ b/Mobiflight/GNC255/MFCustomDevice.cpp
@@ -43,11 +43,6 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
-{
-    attach(adrPin, adrType, adrConfig);
-}
-
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/Mobiflight/GNC255/MFCustomDevice.h
+++ b/Mobiflight/GNC255/MFCustomDevice.h
@@ -7,7 +7,6 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
-    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(int16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/Mobiflight/GenericI2C/MFCustomDevice.cpp
+++ b/Mobiflight/GenericI2C/MFCustomDevice.cpp
@@ -43,11 +43,6 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
-{
-    attach(adrPin, adrType, adrConfig);
-}
-
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/Mobiflight/GenericI2C/MFCustomDevice.h
+++ b/Mobiflight/GenericI2C/MFCustomDevice.h
@@ -11,7 +11,6 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
-    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/_all_CustomDevices/MFCustomDevice.cpp
+++ b/_all_CustomDevices/MFCustomDevice.cpp
@@ -48,11 +48,6 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
-{
-    attach(adrPin, adrType, adrConfig);
-}
-
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/_all_CustomDevices/MFCustomDevice.h
+++ b/_all_CustomDevices/MFCustomDevice.h
@@ -17,7 +17,6 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
-    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();

--- a/_template/MFCustomDevice.cpp
+++ b/_template/MFCustomDevice.cpp
@@ -43,11 +43,6 @@ MFCustomDevice::MFCustomDevice()
     _initialized = false;
 }
 
-MFCustomDevice::MFCustomDevice(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig)
-{
-    attach(adrPin, adrType, adrConfig);
-}
-
 /* **********************************************************************************
     Within the connector pins, a device name and a config string can be defined
     These informations are stored in the EEPROM like for the other devices.

--- a/_template/MFCustomDevice.h
+++ b/_template/MFCustomDevice.h
@@ -12,7 +12,6 @@ class MFCustomDevice
 {
 public:
     MFCustomDevice();
-    MFCustomDevice(uint16_t adrPin = 0, uint16_t adrType = 0, uint16_t adrConfig = 0);
     void attach(uint16_t adrPin, uint16_t adrType, uint16_t adrConfig);
     void detach();
     void update();


### PR DESCRIPTION
The function calls for the custom device class was changed in the firmware repo.

To fit these changed calls the constructor must not have any variables. Instead the attach() function is used which is already available.