### PR TITLE
GNC255 - Fix that an unknown device gets stil loaded

### DIFF
--- a/Mobiflight/GNC255/MFCustomDevice.cpp
+++ b/Mobiflight/GNC255/MFCustomDevice.cpp
@@ -70,7 +70,7 @@ void MFCustomDevice::attach(int16_t adrPin, uint16_t adrType, uint16_t adrConfig
         is used to store the type
     ********************************************************************************************** */
     getStringFromEEPROM(adrType, parameter);
-    if (strcmp(parameter, "MOBIFLIGHT_GNC255") == 1) {
+    if (strcmp(parameter, "MOBIFLIGHT_GNC255") != 0) {
         cmdMessenger.sendCmd(kStatus, F("Custom Device is not supported by this firmware version"));
         return;
     }


### PR DESCRIPTION
Within `MFCustomDevice.cpp' it is checked if this custom device FW supports the configured devices saved in the EEPROM.

It does not work and is fixed with this change.

Fixes #37 